### PR TITLE
fix(completion): support scripts with `:` & `-` characters

### DIFF
--- a/bin/completion.sh
+++ b/bin/completion.sh
@@ -11,7 +11,7 @@ function _nrun_completion() {
     local cur tasks
     cur=${COMP_WORDS[COMP_CWORD]}
     # The sed command strips terminal escape sequences.
-    tasks=$(nrun | grep '^  [a-zA-Z0-9]*$' | awk '{print $1}')
+    tasks=$(nrun | grep '^  [a-zA-Z0-9:-]*$' | awk '{print $1}')
     if [ $COMP_CWORD -eq 1 ]; then
         # Task name completion for first argument.
         COMPREPLY=( $(compgen -W "$tasks" "$cur") )

--- a/bin/completion.sh
+++ b/bin/completion.sh
@@ -9,15 +9,15 @@
 
 function _nrun_completion() {
     local cur tasks
-    cur=${COMP_WORDS[COMP_CWORD]}
+    _get_comp_words_by_ref -n : cur
     # The sed command strips terminal escape sequences.
     tasks=$(nrun | grep '^  [a-zA-Z0-9:-]*$' | awk '{print $1}')
-    if [ $COMP_CWORD -eq 1 ]; then
+    if [[ $COMP_LINE =~ ^${COMP_WORDS[0]}\ [^\ ]+\  ]]; then
+        COMPREPLY=( $(compgen -f "$cur") )
+    else
         # Task name completion for first argument.
         COMPREPLY=( $(compgen -W "$tasks" "$cur") )
-    else
-        # File name completion for other arguments.
-        COMPREPLY=( $(compgen -f "$cur") )
+        __ltrim_colon_completions "$cur"
     fi
 }
 complete -F _nrun_completion nrun


### PR DESCRIPTION
🌮 